### PR TITLE
fix(esp32/wifi): multi-fragment messages were undeliverable with the default UDP mailbox

### DIFF
--- a/firmware/esp32/components/latentmesh_air/src/lm_air_wifi.c
+++ b/firmware/esp32/components/latentmesh_air/src/lm_air_wifi.c
@@ -26,8 +26,12 @@
  * is dropped inside the stack and reassembly silently never completes.  See
  * sdkconfig.defaults. */
 #if CONFIG_LWIP_UDP_RECVMBOX_SIZE < LM_AIR_MAX_FRAGMENTS
-#warning "CONFIG_LWIP_UDP_RECVMBOX_SIZE is smaller than LM_AIR_MAX_FRAGMENTS: \
-multi-fragment messages longer than the mailbox will be undeliverable"
+/* Deliberately #pragma message and not #warning: a tree that already has a
+ * generated sdkconfig keeps it in preference to sdkconfig.defaults, so #warning
+ * becomes a hard build failure under -Werror=cpp for anyone who merely pulls
+ * this change without reconfiguring. The same condition is reported at runtime
+ * in lm_air_wifi_start(). */
+#pragma message("CONFIG_LWIP_UDP_RECVMBOX_SIZE is smaller than LM_AIR_MAX_FRAGMENTS: long messages will not reassemble; see sdkconfig.defaults")
 #endif
 
 static const char *TAG = "lm_wifi";
@@ -122,6 +126,12 @@ static void udp_task(void *arg)
 
 esp_err_t lm_air_wifi_start(void)
 {
+#if CONFIG_LWIP_UDP_RECVMBOX_SIZE < LM_AIR_MAX_FRAGMENTS
+    ESP_LOGW(TAG,
+             "UDP receive mailbox holds %d datagrams but a message can be %d "
+             "fragments; messages longer than the mailbox will not reassemble",
+             (int)CONFIG_LWIP_UDP_RECVMBOX_SIZE, (int)LM_AIR_MAX_FRAGMENTS);
+#endif
     if (CONFIG_LM_WIFI_SSID[0] == '\0') {
         ESP_LOGW(TAG, "%s", "Wi-Fi adapter dormant: configure LM_WIFI_SSID");
         return ESP_OK;

--- a/firmware/esp32/components/latentmesh_air/src/lm_air_wifi.c
+++ b/firmware/esp32/components/latentmesh_air/src/lm_air_wifi.c
@@ -14,8 +14,21 @@
 #include "lwip/inet.h"
 #include "lwip/sockets.h"
 
+#include "latentmesh_air.h"
 #include "lm_air_metrics.h"
 #include "lm_air_radio.h"
+
+/* lm_air_tx_send() drains every fragment of a message into the link queue in a
+ * tight loop, and udp_task sends each one immediately, so an N-fragment message
+ * reaches the peer as a burst of N datagrams with no pacing.  The receiving
+ * socket must be able to hold that burst: if LWIP's UDP receive mailbox is
+ * smaller than the largest message in fragments, the tail of every long message
+ * is dropped inside the stack and reassembly silently never completes.  See
+ * sdkconfig.defaults. */
+#if CONFIG_LWIP_UDP_RECVMBOX_SIZE < LM_AIR_MAX_FRAGMENTS
+#warning "CONFIG_LWIP_UDP_RECVMBOX_SIZE is smaller than LM_AIR_MAX_FRAGMENTS: \
+multi-fragment messages longer than the mailbox will be undeliverable"
+#endif
 
 static const char *TAG = "lm_wifi";
 static EventGroupHandle_t s_events;

--- a/firmware/esp32/sdkconfig.defaults
+++ b/firmware/esp32/sdkconfig.defaults
@@ -24,3 +24,12 @@ CONFIG_LM_OPERATOR_ATTESTED=n
 CONFIG_LM_RF_TX_INTERLOCK_GPIO=-1
 CONFIG_LM_MAX_FRAME_SIZE=512
 CONFIG_LM_QUEUE_DEPTH=8
+
+# A semantic message larger than one fragment is emitted as a back-to-back
+# burst of UDP datagrams, one per fragment, with no pacing.  LWIP's default UDP
+# receive mailbox holds 6, so a burst longer than that overflows the socket
+# before the receive task can drain it and reassembly can never complete.  With
+# the default the practical ceiling was about 8 fragments (~1700 bytes) even
+# though LM_AIR_MAX_FRAGMENTS is 32.  Size the mailbox to hold a full
+# maximum-length burst plus headroom for a second sender.
+CONFIG_LWIP_UDP_RECVMBOX_SIZE=64


### PR DESCRIPTION
Fixes #25.

An N-fragment message is emitted as a burst of N UDP datagrams with no pacing (`lm_air_tx_send`, `air.c:318-341` → `lm_air_radio_publish` → `udp_task`'s `sendto`). LWIP's default UDP receive mailbox holds 6, so a longer burst overflows the socket inside the stack, the tail is discarded, and reassembly never completes — deterministically.

Measured on two ESP32-S3 boards over a real AP, cross-matching sender and receiver by `(source_id, message_id, length, CRC16)`:

| Fragments | mailbox 6 | mailbox 64 |
|---:|---|---|
| 6 | 80 % | 70 % |
| 7 | 80 % | 60 % |
| 8 | 40 % | 40 % |
| 9 | **0 %** | 38 % |
| 10–11 | **0 %** | 12–38 % |
| 12 | **0 %** | 25 % |

`LM_AIR_MAX_FRAGMENTS` is 32, so the practical ceiling was roughly a quarter of the advertised maximum message size.

## What this does

- Sizes `CONFIG_LWIP_UDP_RECVMBOX_SIZE` in `sdkconfig.defaults` to hold a full maximum-length burst plus headroom.
- Adds a check in the Wi-Fi transport tying that value to `LM_AIR_MAX_FRAGMENTS`, so the coupling cannot regress unnoticed.

## Two notes for review

**The check is `#pragma message`, not `#warning`, on purpose.** `sdkconfig` is gitignored, so a contributor with an already-generated config keeps it in preference to `sdkconfig.defaults`. With `#warning` under `-Werror=cpp` that turns into a hard build failure for anyone who merely pulls this change without reconfiguring — we reproduced exactly that and backed it out. The same condition is also reported at runtime in `lm_air_wifi_start()`, where it is actionable. Happy to make it stricter if you would rather.

**This fix is partial.** It removes the deterministic wall and leaves ordinary burst loss underneath (12–50 % at high fragment counts). Fragment pacing or reassembly-aware flow control would be the real answer, and `lm_air_pipeline_send` returning `ESP_OK` for a message that never arrives is arguably the deeper issue.

Two other hypotheses were tested and rejected first, each by changing one variable: raising `CONFIG_LM_QUEUE_DEPTH` 8→16 changed nothing, and switching broadcast→unicast changed nothing.

**Not measured:** the heap cost. Analytically it should be ~232 bytes (LWIP mailboxes store pointers), and structurally unlike `CONFIG_LM_QUEUE_DEPTH`, which sizes frame-sized items and does exhaust RAM at 64. Whether 32 (`LM_AIR_MAX_FRAGMENTS`) is more principled than 64 is a fair question — happy to change it.
