### PR TITLE
feat(esp32): optional demo beacon so a two-node link can be observed

### DIFF
--- a/firmware/esp32/README.md
+++ b/firmware/esp32/README.md
@@ -71,6 +71,34 @@ The committed default has no WiFi credentials and external RF transmission is
 off. Do not commit credentials in `sdkconfig`. Use a local defaults file, NVS
 provisioning in a downstream product, or menuconfig.
 
+## Seeing the link work
+
+By default `app_main` starts the transports and returns. Nothing transmits, and
+the default `lm_air_pipeline_message_hook` is a no-op, so two freshly flashed
+boards associate and then sit silent in both directions. That is deliberate --
+the firmware does not become a transmitting station on first boot -- but it
+means there is no built-in way to tell whether the link works.
+
+Enable the demo beacon on two boards to get an observable round trip:
+
+```sh
+idf.py menuconfig    # LatentMesh Air -> Send a periodic demo beacon
+idf.py build flash monitor
+```
+
+Each node then sends a small message on its enabled links and logs what it
+receives:
+
+```
+demo beacon enabled; source=269090 period=3000ms bytes=64
+demo tx: message=0 bytes=64 result=ESP_OK
+demo rx: source=27B460 message=0 bytes=64 authenticated=0
+```
+
+The beacon never enables external RF transmission; that stays gated by
+`LM_RF_TX_ENABLE` and the operator interlock. Turn it off for anything other
+than bring-up.
+
 Native deterministic tests do not require ESP IDF:
 
 ```sh

--- a/firmware/esp32/main/Kconfig.projbuild
+++ b/firmware/esp32/main/Kconfig.projbuild
@@ -10,6 +10,32 @@ config LM_QUEUE_DEPTH
     range 2 64
     default 8
 
+config LM_DEMO_BEACON
+    bool "Send a periodic demo beacon and log received messages"
+    default n
+    help
+        Off by default: enabling it makes the node transmit on its enabled
+        links.  It never enables external RF transmission, which stays gated by
+        LM_RF_TX_ENABLE and the operator interlock.
+
+        With this off, app_main starts the transports and returns, and the
+        default lm_air_pipeline_message_hook is a no-op, so a freshly flashed
+        pair of nodes is silent in both directions and there is no built-in way
+        to see whether the link works.  Enable this on two boards to get an
+        observable end-to-end round trip.
+
+config LM_DEMO_BEACON_PERIOD_MS
+    int "Demo beacon period in milliseconds"
+    range 250 60000
+    default 5000
+    depends on LM_DEMO_BEACON
+
+config LM_DEMO_BEACON_BYTES
+    int "Demo beacon body bytes"
+    range 1 1024
+    default 64
+    depends on LM_DEMO_BEACON
+
 config LM_STREAM_ID
     int "Base Air stream identifier"
     range 1 65532

--- a/firmware/esp32/main/app_main.c
+++ b/firmware/esp32/main/app_main.c
@@ -47,11 +47,24 @@ static void demo_beacon_task(void *arg)
     uint32_t sequence = 0;
 
     for (;;) {
-        const int header = snprintf((char *)body, sizeof(body),
-                                    "latentmesh demo %06lX %lu ",
-                                    (unsigned long)(s_demo_source_id & 0xFFFFFFu),
-                                    (unsigned long)sequence);
-        for (size_t i = (header > 0 ? (size_t)header : 0u); i < sizeof(body); i++) {
+        /* Render the header into a fixed scratch buffer rather than straight
+         * into body[]: body is sized by Kconfig and can legally be smaller
+         * than the header, which makes a direct snprintf into it a
+         * statically-provable truncation and so a -Werror=format-truncation
+         * build failure across much of the configurable range. */
+        char header[40];
+        const int header_len = snprintf(header, sizeof(header),
+                                        "latentmesh demo %06lX %lu ",
+                                        (unsigned long)(s_demo_source_id & 0xFFFFFFu),
+                                        (unsigned long)sequence);
+        const size_t copied =
+            (header_len > 0 && (size_t)header_len < sizeof(body))
+                ? (size_t)header_len
+                : 0u;
+        if (copied != 0u) {
+            memcpy(body, header, copied);
+        }
+        for (size_t i = copied; i < sizeof(body); i++) {
             body[i] = (uint8_t)('A' + ((i + sequence) % 26u));
         }
 

--- a/firmware/esp32/main/app_main.c
+++ b/firmware/esp32/main/app_main.c
@@ -1,6 +1,14 @@
+#include <stdio.h>
+#include <string.h>
+
 #include "esp_check.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
+#if CONFIG_LM_DEMO_BEACON
+#include "esp_mac.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#endif
 
 #include "lm_air_ble.h"
 #include "lm_air_i2s.h"
@@ -12,6 +20,84 @@
 #include "lm_air_wifi.h"
 
 static const char *TAG = "latentmesh_air";
+
+#if CONFIG_LM_DEMO_BEACON
+/* Identifies this node to its peers.  The low three bytes of the station MAC
+ * are enough to tell two boards apart on a bench. */
+static uint32_t s_demo_source_id;
+
+/* Overrides the weak no-op in lm_air_pipeline so a received message is visible
+ * without writing any application code. */
+void lm_air_pipeline_message_hook(const lm_air_message_t *message)
+{
+    if (message == NULL) {
+        return;
+    }
+    ESP_LOGI(TAG, "demo rx: source=%06lX message=%lu bytes=%u authenticated=%u",
+             (unsigned long)(message->source_id & 0xFFFFFFu),
+             (unsigned long)message->message_id,
+             (unsigned)message->body_len,
+             (unsigned)message->authenticated);
+}
+
+static void demo_beacon_task(void *arg)
+{
+    (void)arg;
+    static uint8_t body[CONFIG_LM_DEMO_BEACON_BYTES];
+    uint32_t sequence = 0;
+
+    for (;;) {
+        const int header = snprintf((char *)body, sizeof(body),
+                                    "latentmesh demo %06lX %lu ",
+                                    (unsigned long)(s_demo_source_id & 0xFFFFFFu),
+                                    (unsigned long)sequence);
+        for (size_t i = (header > 0 ? (size_t)header : 0u); i < sizeof(body); i++) {
+            body[i] = (uint8_t)('A' + ((i + sequence) % 26u));
+        }
+
+        lm_air_message_t message = {
+            .source_id = s_demo_source_id,
+            .epoch = 1,
+            .message_id = sequence,
+            .logical_sequence = sequence,
+            .class_id = 1,
+            .priority = 15,
+            .body = body,
+            .body_len = (uint16_t)sizeof(body),
+        };
+        const uint32_t links =
+#if CONFIG_LM_WIFI_ENABLE
+            LM_AIR_LINK_MASK(LM_AIR_LINK_WIFI) |
+#endif
+#if CONFIG_LM_BLE_ENABLE
+            LM_AIR_LINK_MASK(LM_AIR_LINK_BLE) |
+#endif
+            0u;
+        if (links != 0u) {
+            const esp_err_t err = lm_air_pipeline_send(&message, links,
+                                                       LM_AIR_PAYLOAD_PUBLIC_CODEC);
+            ESP_LOGI(TAG, "demo tx: message=%lu bytes=%u result=%s",
+                     (unsigned long)sequence, (unsigned)sizeof(body),
+                     esp_err_to_name(err));
+        }
+        sequence++;
+        vTaskDelay(pdMS_TO_TICKS(CONFIG_LM_DEMO_BEACON_PERIOD_MS));
+    }
+}
+
+static void start_demo_beacon(void)
+{
+    uint8_t mac[6] = {0};
+    ESP_ERROR_CHECK(esp_read_mac(mac, ESP_MAC_WIFI_STA));
+    s_demo_source_id = ((uint32_t)mac[3] << 16) | ((uint32_t)mac[4] << 8) |
+                       (uint32_t)mac[5];
+    ESP_LOGI(TAG, "demo beacon enabled; source=%06lX period=%ums bytes=%u",
+             (unsigned long)s_demo_source_id,
+             (unsigned)CONFIG_LM_DEMO_BEACON_PERIOD_MS,
+             (unsigned)CONFIG_LM_DEMO_BEACON_BYTES);
+    xTaskCreate(demo_beacon_task, "lm_demo", 4096, NULL, 5, NULL);
+}
+#endif /* CONFIG_LM_DEMO_BEACON */
 
 static esp_err_t start_transports(void)
 {
@@ -55,4 +141,8 @@ void app_main(void)
     ESP_LOGI(TAG, "transport tasks started; max frame=%u bytes, queue depth=%u",
              (unsigned)CONFIG_LM_MAX_FRAME_SIZE,
              (unsigned)CONFIG_LM_QUEUE_DEPTH);
+
+#if CONFIG_LM_DEMO_BEACON
+    start_demo_beacon();
+#endif
 }


### PR DESCRIPTION
Fixes #24.

`app_main` starts the transports and returns, and the default `lm_air_pipeline_message_hook` is a weak no-op that does not even log, so two freshly flashed boards are silent in both directions and nothing demonstrates that the link works.

## What this does

Adds `LM_DEMO_BEACON`, **off by default**, which sends a small periodic message on the enabled links and overrides the receive hook to log what arrives. It never enables external RF transmission; that stays gated by `LM_RF_TX_ENABLE` and the operator interlock.

With the option off, the image is byte-identical in size to before (491,504 bytes) and behaviour is unchanged.

```
demo beacon enabled; source=269090 period=3000ms bytes=64
demo tx: message=0 bytes=64 result=ESP_OK
demo rx: source=27B460 message=0 bytes=64 authenticated=0
```

## Verification

Two ESP32-S3 boards over a real AP: 14 sent and 14 received on each node, both directions. Also run at both ends of the Kconfig range, `BYTES=1` and `BYTES=1024`: no reboots, no aborts.

The header is rendered into a fixed scratch buffer rather than straight into `body[]`, because `body[]` is sized by Kconfig and can legally be smaller than the header — `snprintf`-ing directly into it is a statically-provable truncation and fails the build under `-Werror=format-truncation` for much of the declared range. The full 1..1024 range builds.

## Two things worth knowing

- With both Wi-Fi and BLE disabled, the beacon logs "enabled" and then does nothing. Harmless but it reads oddly; happy to add a warning.
- Enabling this BLE-only with a body large enough to fragment would be the first time `lm_air_ble_frag.c` runs on real hardware, so the new README section points users at a path with no prior hardware coverage. Worth being aware of before merging.
